### PR TITLE
Don't break docker when highstating.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Version 2.0.0
+
+* Play well with other apps modifying iptables. 
+* *WARNING*: Rules are now applied one by one at the time they're defined, and not in one go.
+
 ## Version 1.1.2
 
 * Always allow 127.0.0.0/8

--- a/firewall/init.sls
+++ b/firewall/init.sls
@@ -6,19 +6,10 @@ iptables:
 
 {%- if firewall.enabled %}
 
-/etc/iptables-rules:
-  file.managed:
-    - source: salt://firewall/templates/iptables-rules
-    - template: jinja
-    - user: root
-    - group: root
-
-
-firewall-apply:
+firewall-save:
   cmd.run:
-    - name: 'cat /etc/iptables-rules | /sbin/iptables-restore'
-    - unless: diff -u -B <( iptables-save | sed -r 's/\[[0-9]+\:[0-9]+\]/[0:0]/' | grep -v '^#') <( cat /etc/iptables-rules )
-
+    - name: iptables-save |sed -r 's/\[[0-9]+\:[0-9]+\]/[0:0]/' | grep -v '^#' > /etc/iptables.rules
+    - unless: diff -u -B <( iptables-save | sed -r 's/\[[0-9]+\:[0-9]+\]/[0:0]/' | grep -v '^#') <( cat /etc/iptables.rules )
 {%- endif %}
 
 {% from 'firewall/lib.sls' import firewall_enable with context %}


### PR DESCRIPTION
The current way the formula works does not play well with other
apps that change iptables rules on their own (for example Docker).

This PR changes the logic and inserts rules in the current
ruleset using iptables commands and then saves the resulting current state, 
instead of generating the full ruleset in a template and leave external changes 
out as a result.
